### PR TITLE
Introduce a changelog file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+
+## [3.0.0] — 2025-03-26
+### Changed
+* Update project to use [model2owl 3.0.0](https://github.com/OP-TED/model2owl/releases/tag/3.0.0)
+* Update GitHub Actions to explicitly pass a namespaces file to model2owl toolkit commands
+* Update test files
+* Change the versioning scheme to align with the used [model2owl](https://github.com/OP-TED/[model2owl](https://github.com/OP-TED/model2owl)) version


### PR DESCRIPTION
This change adds a dedicated changelog file to track modifications in the project. Going forward, release candidate versions will be documented in this changelog instead of using GitHub release pages.

The added file contains documentation of changes for the past release.